### PR TITLE
Adds new doc section for lost-vars.

### DIFF
--- a/_docs/lost-vars.md
+++ b/_docs/lost-vars.md
@@ -1,0 +1,20 @@
+---
+title: "Lost Variables"
+nav: "lost-vars"
+code-example: "true"
+type: "function"
+description: "Use to output Lost Variables anywhere in the project to help consistency and readability."
+rules:
+  - rule: "gutter"
+    description: "Outputs the value of the global gutter. Use this anywhere in your project."
+  - rule: "gutter-local"
+    description: "Outputs the value of the gutter for that particular declaration."
+---
+
+{% highlight css %}
+.hero-area {
+  lost-column: 1/3 4 50px;
+  padding: lost-vars('gutter-local'); /* 50px */
+  margin-top: lost-vars('gutter'); /* 30px default gutter */
+}
+{% endhighlight %}


### PR DESCRIPTION
I wasn't able to generate locally using Jekyll v3.5.0, so I haven't checked out whether this looks ok or not. Kept getting the following error:

`jekyll 3.5.0 | Error:  undefined method 'registers' for nil:NilClass`

No idea what that's all about! If you do, please let me know. Incidentally what version of Jekyll so you use?

So anyway, wasn't sure if I needed to do anything else to add a new section. If there is, let me know and I'll add it.